### PR TITLE
[STATBOT-002] - Specific dinners based on matchtype

### DIFF
--- a/app/services/statbot/player_data.rb
+++ b/app/services/statbot/player_data.rb
@@ -11,7 +11,9 @@ module Statbot
             @damage = 0 
             @best_damage = 0
             @deaths = 0 
-            @chicken_dinners = 0
+            @casual_chicken_dinners = 0
+            @unranked_chicken_dinners = 0
+            @ranked_chicken_dinners = 0
             @longest_kill = 0
             @revives = 0
             @team_kills = 0
@@ -28,13 +30,21 @@ module Statbot
             @assists += stats["assists"]
             @best_damage = stats["damageDealt"] if stats["damageDealt"] > @best_damage
             @deaths += 1 unless stats["deathType"] == "alive"
-            @chicken_dinners +=1 if stats["winPlace"] == 1
             @best_finish = stats["winPlace"] if stats["winPlace"] < @best_finish
             @longest_kill = stats["longestKill"] if stats["longestKill"] > @longest_kill
             @revives += stats["revives"]
             @team_kills += stats["teamKills"]
             @splatters += stats["roadKills"]
             @vehicle_destroys += stats["vehicleDestroys"]
+
+            # locally scope matchType for conditionals
+            matchType = stats["matchType"]
+            # casual - 'airoyal'
+            @casual_chicken_dinners += 1 if stats["winPlace"] == 1 && matchType == "airoyal"
+            # unranked - 'official'
+            @unranked_chicken_dinners += 1 if stats["winPlace"] == 1 && matchType == "official"
+            # ranked - 'competitive'
+            @ranked_chicken_dinners += 1 if stats["winPlace"] == 1 && matchType == "competitive"
         end
 
         def kd_ratio
@@ -68,7 +78,9 @@ module Statbot
         
         def calc_dinners
             res = ""
-            @chicken_dinners.times { res << "🍗 " }
+            @casual_chicken_dinners.times { res << "🦾 " }
+            @unranked_chicken_dinners.times { res << "🍗 " }
+            @ranked_chicken_dinners.times { res << "🏆 " }
             res
         end
 

--- a/app/services/statbot/player_data_factory.rb
+++ b/app/services/statbot/player_data_factory.rb
@@ -49,9 +49,15 @@ module Statbot
 
             return unless within_time_window(match)
             return unless correct_game_mode(match)
+
+            matchType = get_match_type(match)
+
             match = match["included"].select { |i| i["type"] == "participant"}.filter do |p|
                 player_name == (p["attributes"]["stats"]["name"])
             end
+
+            # append matchType for use by add_match_stats
+            match["matchType"] = matchType
         end 
 
         def within_time_window(m)
@@ -65,6 +71,10 @@ module Statbot
 
         def correct_game_mode(m)
             m["data"]["attributes"]["gameMode"] == game_mode
+        end
+
+        def get_match_type(m) 
+            m["data"]["attributes"]["matchType"]
         end
 
         def get(request_path="")


### PR DESCRIPTION
This has not been tested at all but based on the api response shape, it should work.

I'm appending the matchType of the match to the player data response object for that match so it can be consumed by the PlayerData instance.

Please review this thoroughly and confirm the changes work as I have brain fog and I don't trust my COVID self.

Also, it would be super helpful if you could add a startup/how to test section in the README.